### PR TITLE
이슈 편집 기능 구현

### DIFF
--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -3,13 +3,16 @@
 import { useEffect, useState, startTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { ISSUES_STORAGE_KEY } from '@/constants/planning';
-import type { GenerateIssuesResult } from '@/types/github';
+import type { GenerateIssuesResult, GeneratedIssue } from '@/types/github';
 import { GenerateIssuesSchema } from '@/features/issues/schemas';
 import IssueCard from '@/features/issues/IssueCard';
+import { saveIssuesToStorage } from '@/features/issues/utils/updateIssuesStorage';
 
 export default function IssuesPage() {
   const router = useRouter();
   const [data, setData] = useState<GenerateIssuesResult | null>(null);
+  const [editingEpicIndex, setEditingEpicIndex] = useState<number | null>(null);
+  const [epicDraft, setEpicDraft] = useState('');
 
   useEffect(() => {
     const raw = sessionStorage.getItem(ISSUES_STORAGE_KEY);
@@ -27,6 +30,40 @@ export default function IssuesPage() {
       router.replace('/');
     }
   }, [router]);
+
+  const handleStoryUpdate = (epicIndex: number, storyIndex: number, updated: GeneratedIssue) => {
+    if (!data) return;
+    const newIssues = data.issues.map((group, i) => {
+      if (i !== epicIndex) return group;
+      return {
+        ...group,
+        stories: group.stories.map((story, j) => (j === storyIndex ? updated : story)),
+      };
+    });
+    const newData = { issues: newIssues };
+    startTransition(() => setData(newData));
+    saveIssuesToStorage(newData);
+  };
+
+  const handleEpicEditStart = (index: number, currentEpic: string) => {
+    setEpicDraft(currentEpic);
+    setEditingEpicIndex(index);
+  };
+
+  const handleEpicSave = (epicIndex: number) => {
+    if (!data) return;
+    const newIssues = data.issues.map((group, i) =>
+      i === epicIndex ? { ...group, epic: epicDraft } : group
+    );
+    const newData = { issues: newIssues };
+    startTransition(() => setData(newData));
+    saveIssuesToStorage(newData);
+    setEditingEpicIndex(null);
+  };
+
+  const handleEpicCancel = () => {
+    setEditingEpicIndex(null);
+  };
 
   if (!data) return <div style={{ padding: '40px' }}>로딩 중...</div>;
 
@@ -63,15 +100,89 @@ export default function IssuesPage() {
               >
                 Epic
               </span>
-              <span style={{ fontSize: '16px', fontWeight: '700', color: '#111827' }}>
-                {group.epic}
-              </span>
+              {editingEpicIndex === i ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flex: 1 }}>
+                  <input
+                    value={epicDraft}
+                    onChange={(e) => setEpicDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleEpicSave(i);
+                      if (e.key === 'Escape') handleEpicCancel();
+                    }}
+                    autoFocus
+                    style={{
+                      flex: 1,
+                      fontSize: '16px',
+                      fontWeight: '700',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '6px',
+                      padding: '4px 8px',
+                      outline: 'none',
+                      color: '#111827',
+                    }}
+                  />
+                  <button
+                    onClick={handleEpicCancel}
+                    style={{
+                      padding: '4px 12px',
+                      background: 'white',
+                      color: '#111827',
+                      border: '1px solid #e5e7eb',
+                      borderRadius: '6px',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={() => handleEpicSave(i)}
+                    style={{
+                      padding: '4px 12px',
+                      background: '#111827',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '6px',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    저장
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <span style={{ fontSize: '16px', fontWeight: '700', color: '#111827', flex: 1 }}>
+                    {group.epic}
+                  </span>
+                  <button
+                    onClick={() => handleEpicEditStart(i, group.epic)}
+                    style={{
+                      background: 'transparent',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: '#9ca3af',
+                      fontSize: '12px',
+                      padding: '2px 6px',
+                      borderRadius: '4px',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.color = '#374151')}
+                    onMouseLeave={(e) => (e.currentTarget.style.color = '#9ca3af')}
+                  >
+                    수정
+                  </button>
+                </>
+              )}
             </div>
 
             {/* Stories */}
             <div>
               {group.stories.map((story, j) => (
-                <IssueCard key={j} issue={story} />
+                <IssueCard
+                  key={j}
+                  issue={story}
+                  onUpdate={(updated) => handleStoryUpdate(i, j, updated)}
+                />
               ))}
             </div>
           </section>

--- a/src/features/issues/IssueCard/index.tsx
+++ b/src/features/issues/IssueCard/index.tsx
@@ -14,12 +14,44 @@ const TYPE_COLOR: Record<string, { background: string; color: string }> = {
 export default function IssueCard({
   issue,
   indent = 0,
+  onUpdate,
 }: {
   issue: GeneratedIssue;
   indent?: number;
+  onUpdate?: (updated: GeneratedIssue) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(issue.title);
+  const [bodyDraft, setBodyDraft] = useState(issue.body);
+
   const badge = TYPE_COLOR[issue.type] ?? { background: '#f3f4f6', color: '#374151' };
+
+  const handleEditStart = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setTitleDraft(issue.title);
+    setBodyDraft(issue.body);
+    setIsEditing(true);
+    setExpanded(true);
+  };
+
+  const handleSave = () => {
+    onUpdate?.({ ...issue, title: titleDraft, body: bodyDraft });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setTitleDraft(issue.title);
+    setBodyDraft(issue.body);
+    setIsEditing(false);
+  };
+
+  const handleChildUpdate = (childIndex: number, updated: GeneratedIssue) => {
+    const updatedChildren = (issue.children ?? []).map((child, i) =>
+      i === childIndex ? updated : child
+    );
+    onUpdate?.({ ...issue, children: updatedChildren });
+  };
 
   return (
     <div style={{ marginLeft: `${indent}px` }}>
@@ -33,36 +65,135 @@ export default function IssueCard({
         }}
       >
         {/* 헤더 */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '10px',
-            padding: '12px 16px',
-            cursor: 'pointer',
-          }}
-          onClick={() => setExpanded((prev) => !prev)}
-        >
-          <span
-            style={{
-              fontSize: '11px',
-              fontWeight: '700',
-              padding: '2px 8px',
-              borderRadius: '4px',
-              flexShrink: 0,
-              ...badge,
-            }}
+        {isEditing ? (
+          <div
+            style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: '8px' }}
           >
-            {TYPE_LABEL[issue.type] ?? issue.type}
-          </span>
-          <span style={{ fontSize: '14px', fontWeight: '600', flex: 1 }}>{issue.title}</span>
-          <span style={{ fontSize: '12px', color: '#9ca3af', flexShrink: 0 }}>
-            {expanded ? '▲' : '▼'}
-          </span>
-        </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span
+                style={{
+                  fontSize: '11px',
+                  fontWeight: '700',
+                  padding: '2px 8px',
+                  borderRadius: '4px',
+                  flexShrink: 0,
+                  ...badge,
+                }}
+              >
+                {TYPE_LABEL[issue.type] ?? issue.type}
+              </span>
+              <input
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                style={{
+                  flex: 1,
+                  fontSize: '14px',
+                  fontWeight: '600',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '6px',
+                  padding: '4px 8px',
+                  outline: 'none',
+                }}
+              />
+            </div>
+            <textarea
+              value={bodyDraft}
+              onChange={(e) => setBodyDraft(e.target.value)}
+              rows={6}
+              style={{
+                width: '100%',
+                fontSize: '13px',
+                color: '#374151',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                padding: '8px',
+                resize: 'vertical',
+                lineHeight: '1.6',
+                outline: 'none',
+                boxSizing: 'border-box',
+                fontFamily: 'inherit',
+              }}
+            />
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={handleCancel}
+                style={{
+                  padding: '6px 16px',
+                  background: 'white',
+                  color: '#111827',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: '6px',
+                  fontSize: '13px',
+                  cursor: 'pointer',
+                }}
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSave}
+                style={{
+                  padding: '6px 16px',
+                  background: '#111827',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '13px',
+                  cursor: 'pointer',
+                }}
+              >
+                저장
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '10px',
+              padding: '12px 16px',
+              cursor: 'pointer',
+            }}
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            <span
+              style={{
+                fontSize: '11px',
+                fontWeight: '700',
+                padding: '2px 8px',
+                borderRadius: '4px',
+                flexShrink: 0,
+                ...badge,
+              }}
+            >
+              {TYPE_LABEL[issue.type] ?? issue.type}
+            </span>
+            <span style={{ fontSize: '14px', fontWeight: '600', flex: 1 }}>{issue.title}</span>
+            <button
+              onClick={handleEditStart}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                color: '#9ca3af',
+                fontSize: '12px',
+                flexShrink: 0,
+                padding: '2px 6px',
+                borderRadius: '4px',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = '#374151')}
+              onMouseLeave={(e) => (e.currentTarget.style.color = '#9ca3af')}
+            >
+              수정
+            </button>
+            <span style={{ fontSize: '12px', color: '#9ca3af', flexShrink: 0 }}>
+              {expanded ? '▲' : '▼'}
+            </span>
+          </div>
+        )}
 
         {/* body */}
-        {expanded && (
+        {!isEditing && expanded && (
           <div
             style={{
               padding: '12px 16px',
@@ -81,7 +212,12 @@ export default function IssueCard({
 
       {/* 하위 이슈 */}
       {issue.children?.map((child, i) => (
-        <IssueCard key={i} issue={child} indent={24} />
+        <IssueCard
+          key={i}
+          issue={child}
+          indent={24}
+          onUpdate={(updated) => handleChildUpdate(i, updated)}
+        />
       ))}
     </div>
   );

--- a/src/features/issues/utils/updateIssuesStorage.ts
+++ b/src/features/issues/utils/updateIssuesStorage.ts
@@ -1,0 +1,6 @@
+import { ISSUES_STORAGE_KEY } from '@/constants/planning';
+import type { GenerateIssuesResult } from '@/types/github';
+
+export const saveIssuesToStorage = (data: GenerateIssuesResult): void => {
+  sessionStorage.setItem(ISSUES_STORAGE_KEY, JSON.stringify(data));
+};


### PR DESCRIPTION


## #️⃣ 연관된 이슈 번호
- Closes #19

<br>

## 📝 작업 내용
- IssueCard에 제목/본문 인라인 편집 모드 추가
- Epic 이름 편집 UI 추가
- 편집 내용 sessionStorage에 즉시 반영

<br>

## 🖼️ 스크린샷 (선택)
<img width="960" height="704" alt="image" src="https://github.com/user-attachments/assets/2d087bd5-3bb2-4c59-89e2-73b3f480d7dd" />

> UI는 추후 수정 예정

<br>

## 테스트 및 검증 내용
- 아직 프로토타입 단계로 테스트는 추가하지 않음


